### PR TITLE
chore: typed route

### DIFF
--- a/async_redux/lib/feature/pokemon_info/pokemon_info_connector.dart
+++ b/async_redux/lib/feature/pokemon_info/pokemon_info_connector.dart
@@ -8,8 +8,6 @@ import 'package:pokedex_flutter_async_redux/state/app_state.dart';
 class PokemonInfoConnector extends StatelessWidget {
   const PokemonInfoConnector({super.key});
 
-  static const route = 'pokemon-info';
-
   @override
   Widget build(BuildContext context) {
     return StoreConnector<AppState, PokemonInfoVm>(

--- a/async_redux/lib/feature/pokemon_list/pokemon_list_connector.dart
+++ b/async_redux/lib/feature/pokemon_list/pokemon_list_connector.dart
@@ -8,8 +8,6 @@ import 'package:pokedex_flutter_async_redux/state/app_state.dart';
 class PokemonListConnector extends StatelessWidget {
   const PokemonListConnector({super.key});
 
-  static const route = '/';
-
   @override
   Widget build(BuildContext context) {
     return StoreConnector<AppState, PokemonListVm>(

--- a/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pokedex_flutter_async_redux/apis/model/pokemon.dart';
-import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_connector.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/list_scaffold.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/pokemon_card.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/search_field.dart';
@@ -13,6 +12,7 @@ import 'package:pokedex_flutter_async_redux/feature/pokemon_list/widgets/theme_c
 import 'package:pokedex_flutter_async_redux/model/union_page_state.dart';
 import 'package:pokedex_flutter_async_redux/utils/const.dart';
 import 'package:pokedex_flutter_async_redux/utils/extension.dart';
+import 'package:pokedex_flutter_async_redux/utils/router.dart';
 import 'package:pokedex_flutter_async_redux/utils/strings.dart';
 import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
 import 'package:pokedex_flutter_async_redux/widgets/loading_indicator.dart';
@@ -113,7 +113,7 @@ class _PokemonListPageState extends State<PokemonListPage> {
 
   void _onTapPokemonCard(Pokemon selectedPokemon) {
     widget.onSelectPokemon(selectedPokemon);
-    context.pushNamed(PokemonInfoConnector.route);
+    PokemonInfoRoute().go(context);
   }
 
   @override

--- a/async_redux/lib/utils/router.dart
+++ b/async_redux/lib/utils/router.dart
@@ -2,9 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_connector.dart';
-import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_page.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
-import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_page.dart';
 
 part 'router.g.dart';
 

--- a/async_redux/lib/utils/router.dart
+++ b/async_redux/lib/utils/router.dart
@@ -2,29 +2,37 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_connector.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_info/pokemon_info_page.dart';
 import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_connector.dart';
+import 'package:pokedex_flutter_async_redux/feature/pokemon_list/pokemon_list_page.dart';
 
-final navigatorKey = GlobalKey<NavigatorState>();
+part 'router.g.dart';
 
 final router = GoRouter(
-  routes: [
-    GoRoute(
-      path: PokemonListConnector.route,
-      builder: (_, __) => const PokemonListConnector(),
-      routes: [
-        GoRoute(
-          path: PokemonInfoConnector.route,
-          name: PokemonInfoConnector.route,
-          builder: (_, __) => const PokemonInfoConnector(),
-        ),
-      ],
-    ),
-  ],
-  initialLocation: PokemonListConnector.route,
+  routes: $appRoutes,
   debugLogDiagnostics: kDebugMode,
   errorBuilder: (_, __) => const PokemonListConnector(),
-  observers: [routeObserver],
-  navigatorKey: navigatorKey,
+  observers: [RouteObserver<ModalRoute<void>>()],
 );
 
-final routeObserver = RouteObserver<ModalRoute<void>>();
+@TypedGoRoute<PokemonListRoute>(
+  path: '/',
+  routes: [
+    TypedGoRoute<PokemonInfoRoute>(
+      path: 'pokemon-info',
+    )
+  ],
+)
+class PokemonListRoute extends GoRouteData with $PokemonListRoute {
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const PokemonListConnector();
+  }
+}
+
+class PokemonInfoRoute extends GoRouteData with $PokemonInfoRoute {
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const PokemonInfoConnector();
+  }
+}

--- a/async_redux/pubspec.lock
+++ b/async_redux/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "89.0.0"
+    version: "85.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
+      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "7.7.1"
   args:
     dependency: transitive
     description:
@@ -58,13 +58,13 @@ packages:
     source: hosted
     version: "2.1.2"
   build:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: build
-      sha256: "5b887c55a0f734b433b3b2d89f9cd1f99eb636b17e268a5b4259258bc916504b"
+      sha256: "825fed4d63050252a0b6e74f2d75844c4a85b664814be6993bd3493fb5239779"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   build_config:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.1"
   dartx:
     dependency: "direct main"
     description:
@@ -397,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.2.2"
+  go_router_builder:
+    dependency: "direct dev"
+    description:
+      name: go_router_builder
+      sha256: "43a109ccf4f804c486f7f7c0e2e11345142ecf456b4cc265f75b33c7e6fe4684"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   graphs:
     dependency: transitive
     description:
@@ -782,10 +790,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: ccf30b0c9fbcd79d8b6f5bfac23199fb354938436f62475e14aea0f29ee0f800
+      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "3.1.0"
   source_helper:
     dependency: transitive
     description:
@@ -1011,5 +1019,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.32.0"

--- a/async_redux/pubspec.yaml
+++ b/async_redux/pubspec.yaml
@@ -23,11 +23,15 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: ^2.8.0
+  build_runner: 2.8.0
   device_preview_screenshot: ^1.0.0
   flutter_lints: ^6.0.0
   freezed: ^3.2.3
   json_serializable: ^6.11.1
+  go_router_builder: ^4.1.0
+
+dependency_overrides:
+  build: ^4.0.1
 
 flutter:
   uses-material-design: true

--- a/riverpod/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/riverpod/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -13,8 +13,6 @@ import 'package:pokedex_flutter_riverpod/widgets/pokemon_type_list.dart';
 class PokemonInfoPage extends ConsumerWidget {
   const PokemonInfoPage({super.key});
 
-  static const route = 'pokemon-info';
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedPokemon = ref.read(selectedPokemonProvider);

--- a/riverpod/lib/feature/pokemon_info/widgets/info_tab_body.dart
+++ b/riverpod/lib/feature/pokemon_info/widgets/info_tab_body.dart
@@ -19,7 +19,7 @@ class InfoTabBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pokemonInfoPageValue = ref.watch(pokemonInfoPageProvider);
-    final selectedPokemon = ref.read(selectedPokemonProvider);
+    final selectedPokemon = ref.watch(selectedPokemonProvider);
     final typeDecorationColor = PokemonColorPicker.typeDecorationColor(selectedPokemon.primaryColor, isDarkened: true);
 
     return pokemonInfoPageValue.when(

--- a/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:pokedex_flutter_riverpod/apis/model/pokemon.dart';
-import 'package:pokedex_flutter_riverpod/feature/pokemon_info/pokemon_info_page.dart';
 import 'package:pokedex_flutter_riverpod/feature/pokemon_list/widgets/infinite_list.dart';
 import 'package:pokedex_flutter_riverpod/feature/pokemon_list/widgets/list_scaffold.dart';
 import 'package:pokedex_flutter_riverpod/feature/pokemon_list/widgets/search_field.dart';
@@ -16,12 +15,11 @@ import 'package:pokedex_flutter_riverpod/providers/selected_pokemon_provider.dar
 import 'package:pokedex_flutter_riverpod/providers/selected_theme_provider.dart';
 import 'package:pokedex_flutter_riverpod/utils/const.dart';
 import 'package:pokedex_flutter_riverpod/utils/extension.dart';
+import 'package:pokedex_flutter_riverpod/utils/router.dart';
 import 'package:pokedex_flutter_riverpod/utils/strings.dart';
 
 class PokemonListPage extends ConsumerStatefulWidget {
   const PokemonListPage({super.key});
-
-  static const route = '/';
 
   @override
   ConsumerState<PokemonListPage> createState() => _PokemonListPageState();
@@ -95,7 +93,7 @@ class _PokemonListPageState extends ConsumerState<PokemonListPage> {
 
   void _onTapPokemonCard(Pokemon selectedPokemon) {
     ref.watch(selectedPokemonProvider.notifier).state = selectedPokemon;
-    context.pushNamed(PokemonInfoPage.route);
+    PokemonInfoRoute().go(context);
   }
 
   @override

--- a/riverpod/lib/utils/router.dart
+++ b/riverpod/lib/utils/router.dart
@@ -4,27 +4,33 @@ import 'package:go_router/go_router.dart';
 import 'package:pokedex_flutter_riverpod/feature/pokemon_info/pokemon_info_page.dart';
 import 'package:pokedex_flutter_riverpod/feature/pokemon_list/pokemon_list_page.dart';
 
-final navigatorKey = GlobalKey<NavigatorState>();
+part 'router.g.dart';
 
 final router = GoRouter(
-  routes: [
-    GoRoute(
-      path: PokemonListPage.route,
-      builder: (_, __) => const PokemonListPage(),
-      routes: [
-        GoRoute(
-          path: PokemonInfoPage.route,
-          name: PokemonInfoPage.route,
-          builder: (_, __) => const PokemonInfoPage(),
-        ),
-      ],
-    ),
-  ],
-  initialLocation: PokemonListPage.route,
+  routes: $appRoutes,
   debugLogDiagnostics: kDebugMode,
   errorBuilder: (_, __) => const PokemonListPage(),
-  observers: [routeObserver],
-  navigatorKey: navigatorKey,
+  observers: [RouteObserver<ModalRoute<void>>()],
 );
 
-final routeObserver = RouteObserver<ModalRoute<void>>();
+@TypedGoRoute<PokemonListRoute>(
+  path: '/',
+  routes: [
+    TypedGoRoute<PokemonInfoRoute>(
+      path: 'pokemon-info',
+    )
+  ],
+)
+class PokemonListRoute extends GoRouteData with $PokemonListRoute {
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const PokemonListPage();
+  }
+}
+
+class PokemonInfoRoute extends GoRouteData with $PokemonInfoRoute {
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const PokemonInfoPage();
+  }
+}

--- a/riverpod/pubspec.lock
+++ b/riverpod/pubspec.lock
@@ -408,6 +408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.2.2"
+  go_router_builder:
+    dependency: "direct dev"
+    description:
+      name: go_router_builder
+      sha256: "43a109ccf4f804c486f7f7c0e2e11345142ecf456b4cc265f75b33c7e6fe4684"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   graphs:
     dependency: transitive
     description:

--- a/riverpod/pubspec.yaml
+++ b/riverpod/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   json_serializable: ^6.11.1
   riverpod_generator: ^3.0.0
   riverpod_lint: ^3.0.0
+  go_router_builder: ^4.1.0
 
 dependency_overrides:
   analyzer_plugin: ^0.13.1


### PR DESCRIPTION
- add go router builder
- lock build runner and override build in async redux
- fix selected pokemon in riverpod info tab body with watch instead of read
- remove routes
- remove unnecessary navigator key
- add pokemon list and info typed routes
- replace push named with routes