### PR TITLE
fix: typed routes

### DIFF
--- a/async_redux/build.yaml
+++ b/async_redux/build.yaml
@@ -1,20 +1,20 @@
 targets:
   $default:
     builders:
+      go_router_builder:
+        generate_for:
+          include:
+            - lib/utils/router.dart
+
       json_serializable:
         options:
           explicit_to_json: true
         generate_for:
-          exclude:
-            - lib
           include:
             - lib/apis/model/*
 
       freezed:
-        enabled: true
         generate_for:
-          exclude:
-            - lib
           include:
             - lib/apis/model/*
             - lib/model/dto/*

--- a/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -113,7 +113,7 @@ class _PokemonListPageState extends State<PokemonListPage> {
 
   void _onTapPokemonCard(Pokemon selectedPokemon) {
     widget.onSelectPokemon(selectedPokemon);
-    PokemonInfoRoute().go(context);
+    PokemonInfoRoute().push<void>(context);
   }
 
   @override

--- a/riverpod/build.yaml
+++ b/riverpod/build.yaml
@@ -1,11 +1,13 @@
 targets:
   $default:
     builders:
-      riverpod_generator:
-        enabled: true
+      go_router_builder:
         generate_for:
-          exclude:
-            - lib
+          include:
+            - lib/utils/router.dart
+
+      riverpod_generator:
+        generate_for:
           include:
             - lib/providers/*
 
@@ -13,16 +15,11 @@ targets:
         options:
           explicit_to_json: true
         generate_for:
-          exclude:
-            - lib
           include:
             - lib/apis/model/*
 
       freezed:
-        enabled: true
         generate_for:
-          exclude:
-            - lib
           include:
             - lib/apis/model/*
             - lib/model/dto/*

--- a/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -93,7 +93,7 @@ class _PokemonListPageState extends ConsumerState<PokemonListPage> {
 
   void _onTapPokemonCard(Pokemon selectedPokemon) {
     ref.watch(selectedPokemonProvider.notifier).state = selectedPokemon;
-    PokemonInfoRoute().go(context);
+    PokemonInfoRoute().push<void>(context);
   }
 
   @override


### PR DESCRIPTION
- use push instead of go when tapping pokemon card
- add go router builder in build yaml
- remove exclude and enabled in json serializable, freezed, and riverpod generator in build yamls