### PR TITLE
feat: [Bloc] get more pokemon

### DIFF
--- a/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -46,17 +46,10 @@ class PokemonListPage extends StatefulWidget {
 }
 
 class _PokemonListPageState extends State<PokemonListPage> {
-  late final _scrollController = ScrollController();
-  late final _textEditingController = TextEditingController();
+  late final _scrollController = ScrollController()..addListener(_onReachEnd);
+  late final _textEditingController = TextEditingController()..addListener(_onUpdateText);
   late final _isSearchingNotifier = ValueNotifier(false);
   Timer? _debouncer;
-
-  @override
-  void initState() {
-    _scrollController.addListener(_onReachEnd);
-    _textEditingController.addListener(_onUpdateText);
-    super.initState();
-  }
 
   @override
   void dispose() {

--- a/bloc/lib/cubit/app_state.dart
+++ b/bloc/lib/cubit/app_state.dart
@@ -12,6 +12,6 @@ abstract class AppState with _$AppState {
     @Default(ThemeMode.system) ThemeMode themeMode,
     @Default(SimplePokemonList()) SimplePokemonList simplePokemonList,
     @Default(<Pokemon>[]) PokemonList pokemonList,
-    @Default(false) bool isLoading,
+    @Default('') String waitKey,
   }) = _AppState;
 }

--- a/bloc/lib/feature/pokemon_list/widgets/list_footer.dart
+++ b/bloc/lib/feature/pokemon_list/widgets/list_footer.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pokedex_flutter_bloc/cubit/app_cubit.dart';
+import 'package:pokedex_flutter_bloc/cubit/app_state.dart';
+import 'package:pokedex_flutter_bloc/utils/const.dart';
+import 'package:pokedex_flutter_bloc/utils/strings.dart';
+import 'package:pokedex_flutter_bloc/widgets/loading_indicator.dart';
+
+class ListFooter extends StatelessWidget {
+  const ListFooter({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AppCubit, AppState>(
+      buildWhen: (previous, current) {
+        final previousKey = previous.waitKey;
+        final currentKey = current.waitKey;
+        final isLoading = previousKey == '' && currentKey == getMorePokemonKey;
+        final isDone = previousKey == getMorePokemonKey && currentKey == '';
+        return isLoading || isDone;
+      },
+      builder: (_, state) => state.waitKey == getMorePokemonKey
+          ? const SliverToBoxAdapter(
+              child: Padding(
+                padding: progressIndicatorFooterPadding,
+                child: LoadingIndicator(),
+              ),
+            )
+          : const SliverToBoxAdapter(child: SizedBox(height: pokemonListPageFooterHeight)),
+    );
+  }
+}

--- a/bloc/lib/utils/const.dart
+++ b/bloc/lib/utils/const.dart
@@ -10,3 +10,4 @@ const typeNameRadius = 20.0;
 const pokemonListPagePadding = EdgeInsets.symmetric(horizontal: 12.0);
 const pokemonGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 250, childAspectRatio: 3 / 2);
 const pokemonListPageFooterHeight = 100.0;
+const progressIndicatorFooterPadding = EdgeInsets.all(12.0);

--- a/bloc/lib/utils/strings.dart
+++ b/bloc/lib/utils/strings.dart
@@ -3,3 +3,5 @@ const appTitle = 'Pokedex';
 const themeSharedPrefsKey = 'theme';
 const baseUrl = 'https://pokeapi.co/api/v2';
 const emptyPokemonLabel = 'No Pokemon Found';
+const getMorePokemonKey = 'get-more-pokemon';
+const initPokemonListKey = 'init-pokemon-list';

--- a/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -26,17 +26,10 @@ class PokemonListPage extends ConsumerStatefulWidget {
 }
 
 class _PokemonListPageState extends ConsumerState<PokemonListPage> {
-  late final _scrollController = ScrollController();
-  late final _textEditingController = TextEditingController();
+  late final _scrollController = ScrollController()..addListener(_onReachEnd);
+  late final _textEditingController = TextEditingController()..addListener(_onUpdateText);
   late final _isSearchingNotifier = ValueNotifier(false);
   Timer? _debouncer;
-
-  @override
-  void initState() {
-    _scrollController.addListener(_onReachEnd);
-    _textEditingController.addListener(_onUpdateText);
-    super.initState();
-  }
 
   @override
   void dispose() {

--- a/riverpod/lib/providers/pokemon_list_provider.dart
+++ b/riverpod/lib/providers/pokemon_list_provider.dart
@@ -27,6 +27,8 @@ class PokemonListRef extends _$PokemonListRef {
   }
 
   void getMorePokemon() async {
+    if (ref.read(loadingProvider) == getMorePokemonKey) return;
+
     ref.read(loadingProvider.notifier).setLoadingKey(getMorePokemonKey);
 
     final nextPageUrl = ref.read(simplePokemonListRefProvider).next;


### PR DESCRIPTION
- change is loading property in app state to string wait key
- add scroll controller in pokemon list page with on reach end listener
- add getting more pokemon method in app cubit
- wrap pokemon list page body with refresh indicator
- create list footer widget for pokemon list page
- directly attach listeners in async redux and riverpod pokemon list page
- fix getting more pokemon in riverpod by avoiding calling if already loading
- add wait key in app cubit loading action function with checking if already loading
- remove get simple and pokemon list functions in app cubit and directly use in init pokemon list page