### PR TITLE
feat: [Bloc] search field

### DIFF
--- a/bloc/lib/classes/adaptive_stateless_widget.dart
+++ b/bloc/lib/classes/adaptive_stateless_widget.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+abstract class AdaptiveStatelessWidget extends StatelessWidget {
+  const AdaptiveStatelessWidget({super.key});
+
+  Widget buildAndroid(BuildContext context);
+
+  Widget buildIos(BuildContext context);
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme.of(context).platform == TargetPlatform.android ? buildAndroid(context) : buildIos(context);
+  }
+}

--- a/bloc/lib/cubit/app_state.dart
+++ b/bloc/lib/cubit/app_state.dart
@@ -13,5 +13,6 @@ abstract class AppState with _$AppState {
     @Default(SimplePokemonList()) SimplePokemonList simplePokemonList,
     @Default(<Pokemon>[]) PokemonList pokemonList,
     @Default('') String waitKey,
+    @Default(false) bool isSearching,
   }) = _AppState;
 }

--- a/bloc/lib/feature/pokemon_list/widgets/search_field.dart
+++ b/bloc/lib/feature/pokemon_list/widgets/search_field.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pokedex_flutter_bloc/classes/adaptive_stateless_widget.dart';
+import 'package:pokedex_flutter_bloc/cubit/app_cubit.dart';
+import 'package:pokedex_flutter_bloc/utils/extension.dart';
+import 'package:pokedex_flutter_bloc/utils/strings.dart';
+
+class SearchField extends AdaptiveStatelessWidget {
+  const SearchField({super.key});
+
+  @override
+  Widget buildAndroid(BuildContext context) {
+    return TextField(
+      autofocus: true,
+      controller: context.read<AppCubit>().textEditingController,
+      decoration: const InputDecoration(
+        prefixIcon: Icon(Icons.search),
+        prefixIconConstraints: BoxConstraints(maxHeight: 20),
+        hintText: searchFieldHintText,
+      ),
+    );
+  }
+
+  @override
+  Widget buildIos(BuildContext context) {
+    return CupertinoTextField(
+      autofocus: true,
+      controller: context.read<AppCubit>().textEditingController,
+      placeholder: searchFieldHintText,
+      style: context.textTheme.bodyLarge,
+      prefix: const Icon(Icons.search),
+    );
+  }
+}

--- a/bloc/lib/utils/strings.dart
+++ b/bloc/lib/utils/strings.dart
@@ -5,3 +5,4 @@ const baseUrl = 'https://pokeapi.co/api/v2';
 const emptyPokemonLabel = 'No Pokemon Found';
 const getMorePokemonKey = 'get-more-pokemon';
 const initPokemonListKey = 'init-pokemon-list';
+const searchFieldHintText = 'Search Pokemon';


### PR DESCRIPTION
- create search field widget
- create adaptive stateless widget and use in search field
- add is search property in app state
- move scroll controller and on reach end function from pokemon list page to app cubit
- initialize text editing controller in app cubit for search field
- update init pokemon list page method in app cubit for initializing controllers and getting initial pokemon list
- add disposing pokemon list page and pressing search methods in app cubit
- wrap app title in pokemon list page with bloc builder for search field
- add search and refresh icon button in pokemon list page