### PR TITLE
feat: [Bloc] pokemon info page

### DIFF
--- a/bloc/lib/extensions/pokemon_ext.dart
+++ b/bloc/lib/extensions/pokemon_ext.dart
@@ -3,6 +3,7 @@ import 'package:flutter/animation.dart';
 import 'package:pokedex_flutter_bloc/apis/model/pokemon.dart';
 import 'package:pokedex_flutter_bloc/classes/pokemon_color_picker.dart';
 import 'package:pokedex_flutter_bloc/extensions/pokemon_type_ext.dart';
+import 'package:pokedex_flutter_bloc/utils/const.dart';
 
 extension PokemonExt on Pokemon {
   Color get primaryColor => PokemonColorPicker.getColor(primaryTypeName);
@@ -10,4 +11,6 @@ extension PokemonExt on Pokemon {
   String get primaryTypeName => typeList.firstOrNull?.name ?? '';
 
   String get capitalizedNamed => name.capitalize();
+
+  String formatId() => '#${id.toString().padLeft(idNumberPadWidth, '0')}';
 }

--- a/bloc/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/bloc/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -1,0 +1,61 @@
+import 'package:auto_route/annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_bloc/apis/model/pokemon.dart';
+import 'package:pokedex_flutter_bloc/extensions/pokemon_ext.dart';
+import 'package:pokedex_flutter_bloc/feature/pokemon_info/widgets/info_scaffold.dart';
+import 'package:pokedex_flutter_bloc/utils/const.dart';
+import 'package:pokedex_flutter_bloc/utils/extension.dart';
+import 'package:pokedex_flutter_bloc/widgets/pokemon_image.dart';
+import 'package:pokedex_flutter_bloc/widgets/pokemon_type_list.dart';
+
+@RoutePage()
+class PokemonInfoPage extends StatelessWidget {
+  const PokemonInfoPage({
+    required this.selectedPokemon,
+    super.key,
+  });
+
+  final Pokemon selectedPokemon;
+
+  @override
+  Widget build(BuildContext context) {
+    final primaryColor = selectedPokemon.primaryColor;
+    final textTheme = context.textTheme;
+
+    return InfoScaffold(
+      color: primaryColor,
+      children: [
+        Padding(
+          padding: infoPageHeaderPadding,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                selectedPokemon.capitalizedNamed,
+                style: textTheme.displayLarge,
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  selectedPokemon.formatId(),
+                  style: textTheme.displaySmall,
+                ),
+              ),
+              PokemonTypeList(
+                pokemon: selectedPokemon,
+                isDecorationShown: true,
+              ),
+              Expanded(
+                flex: context.isPortrait ? 0 : 1,
+                child: PokemonImage(
+                  pokemon: selectedPokemon,
+                  size: infoPageImageSize,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/bloc/lib/feature/pokemon_info/widgets/info_scaffold.dart
+++ b/bloc/lib/feature/pokemon_info/widgets/info_scaffold.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:pokedex_flutter_bloc/classes/adaptive_stateless_widget.dart';
+import 'package:pokedex_flutter_bloc/utils/extension.dart';
+
+class InfoScaffold extends AdaptiveStatelessWidget {
+  const InfoScaffold({
+    required this.children,
+    required this.color,
+    super.key,
+  });
+
+  final Color color;
+  final List<Widget> children;
+
+  @override
+  Widget buildAndroid(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(backgroundColor: color),
+      backgroundColor: color,
+      body: context.isPortrait ? Column(children: children) : Row(children: children),
+    );
+  }
+
+  @override
+  Widget buildIos(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        backgroundColor: color,
+        border: const Border(),
+      ),
+      backgroundColor: color,
+      child: context.isPortrait ? Column(children: children) : Row(children: children),
+    );
+  }
+}

--- a/bloc/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/bloc/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -1,4 +1,4 @@
-import 'package:auto_route/annotations.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pokedex_flutter_bloc/cubit/app_cubit.dart';
@@ -7,6 +7,7 @@ import 'package:pokedex_flutter_bloc/feature/pokemon_list/widgets/list_footer.da
 import 'package:pokedex_flutter_bloc/feature/pokemon_list/widgets/pokemon_card.dart';
 import 'package:pokedex_flutter_bloc/feature/pokemon_list/widgets/search_field.dart';
 import 'package:pokedex_flutter_bloc/model/union_page_state.dart';
+import 'package:pokedex_flutter_bloc/utils/app_router.gr.dart';
 import 'package:pokedex_flutter_bloc/utils/const.dart';
 import 'package:pokedex_flutter_bloc/utils/extension.dart';
 import 'package:pokedex_flutter_bloc/utils/strings.dart';
@@ -83,11 +84,13 @@ class _PokemonListPageState extends State<PokemonListPage> {
                   SliverGrid(
                     gridDelegate: pokemonGridDelegate,
                     delegate: SliverChildBuilderDelegate(
-                      (_, index) => PokemonCard(
-                        pokemon: value[index],
-                        // TODO: Add function
-                        onTap: () {},
-                      ),
+                      (_, index) {
+                        final pokemon = value[index];
+                        return PokemonCard(
+                          pokemon: pokemon,
+                          onTap: () => context.router.navigate(PokemonInfoRoute(selectedPokemon: pokemon)),
+                        );
+                      },
                       childCount: value.length,
                     ),
                   ),

--- a/bloc/lib/utils/app_router.dart
+++ b/bloc/lib/utils/app_router.dart
@@ -9,5 +9,6 @@ class AppRouter extends RootStackRouter {
       page: PokemonListRoute.page,
       initial: true,
     ),
+    AutoRoute(page: PokemonInfoRoute.page),
   ];
 }

--- a/bloc/lib/utils/const.dart
+++ b/bloc/lib/utils/const.dart
@@ -12,3 +12,6 @@ const pokemonGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxi
 const pokemonListPageFooterHeight = 100.0;
 const progressIndicatorFooterPadding = EdgeInsets.all(12.0);
 const debouncerDelayInMilliseconds = 300;
+const idNumberPadWidth = 3;
+const infoPageHeaderPadding = EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0);
+const infoPageImageSize = 200.0;

--- a/bloc/lib/utils/extension.dart
+++ b/bloc/lib/utils/extension.dart
@@ -4,6 +4,8 @@ extension BuildContextExt on BuildContext {
   TextTheme get textTheme => themeData.textTheme;
 
   ThemeData get themeData => Theme.of(this);
+
+  bool get isPortrait => MediaQuery.orientationOf(this) == Orientation.portrait;
 }
 
 extension ListExt<T> on List<T> {


### PR DESCRIPTION
- create initial pokemon info page with imaage, type list, id, and name
- create adaptive info scaffold and use in pokemon info page
- add pokemon info route in app router
- add is portrait getter in extension
- add navigation to pokemon info page in pokemon list page
- add format id method in pokemon extension