### PR TITLE
feat: [Bloc] pokemon info modal

### DIFF
--- a/async_redux/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/async_redux/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -74,43 +74,45 @@ class PokemonInfoPage extends StatelessWidget {
           ),
         ),
         Expanded(
-          child: Container(
-            padding: infoPageModalPadding,
+          child: DecoratedBox(
             decoration: BoxDecoration(
               color: themeData.primaryColor,
               borderRadius: infoPageModalRadius,
             ),
-            child: Material(
-              color: Colors.transparent,
-              child: DefaultTabController(
-                length: tabLabels.length,
-                child: isLoading
-                    ? LoadingIndicator(color: typeDecorationColor)
-                    : Column(
-                        children: [
-                          TabBar(
-                            labelColor: typeDecorationColor,
-                            indicatorColor: typeDecorationColor,
-                            unselectedLabelColor: themeData.unselectedWidgetColor,
-                            tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
-                          ),
-                          Expanded(
-                            child: TabBarView(
-                              children: [
-                                AboutTab(
-                                  selectedPokemon: selectedPokemon,
-                                  flavorTextEnglish: pokemonSpecies.flavorTextEnglish,
-                                ),
-                                EvolutionTab(
-                                  pokemonEvolutionChain: pokemonEvolutionChain,
-                                  pokemonEvolutionList: pokemonEvolutionList,
-                                ),
-                                MovesTab(selectedPokemon: selectedPokemon),
-                              ],
+            child: Padding(
+              padding: infoPageModalPadding,
+              child: Material(
+                color: Colors.transparent,
+                child: DefaultTabController(
+                  length: tabLabels.length,
+                  child: isLoading
+                      ? LoadingIndicator(color: typeDecorationColor)
+                      : Column(
+                          children: [
+                            TabBar(
+                              labelColor: typeDecorationColor,
+                              indicatorColor: typeDecorationColor,
+                              unselectedLabelColor: themeData.unselectedWidgetColor,
+                              tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
                             ),
-                          ),
-                        ],
-                      ),
+                            Expanded(
+                              child: TabBarView(
+                                children: [
+                                  AboutTab(
+                                    selectedPokemon: selectedPokemon,
+                                    flavorTextEnglish: pokemonSpecies.flavorTextEnglish,
+                                  ),
+                                  EvolutionTab(
+                                    pokemonEvolutionChain: pokemonEvolutionChain,
+                                    pokemonEvolutionList: pokemonEvolutionList,
+                                  ),
+                                  MovesTab(selectedPokemon: selectedPokemon),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                ),
               ),
             ),
           ),

--- a/bloc/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/bloc/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -1,10 +1,12 @@
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:pokedex_flutter_bloc/apis/model/pokemon.dart';
+import 'package:pokedex_flutter_bloc/classes/pokemon_color_picker.dart';
 import 'package:pokedex_flutter_bloc/extensions/pokemon_ext.dart';
 import 'package:pokedex_flutter_bloc/feature/pokemon_info/widgets/info_scaffold.dart';
 import 'package:pokedex_flutter_bloc/utils/const.dart';
 import 'package:pokedex_flutter_bloc/utils/extension.dart';
+import 'package:pokedex_flutter_bloc/utils/strings.dart';
 import 'package:pokedex_flutter_bloc/widgets/pokemon_image.dart';
 import 'package:pokedex_flutter_bloc/widgets/pokemon_type_list.dart';
 
@@ -20,7 +22,9 @@ class PokemonInfoPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primaryColor = selectedPokemon.primaryColor;
+    final typeDecorationColor = PokemonColorPicker.typeDecorationColor(primaryColor, isDarkened: true);
     final textTheme = context.textTheme;
+    final themeData = context.themeData;
 
     return InfoScaffold(
       color: primaryColor,
@@ -53,6 +57,39 @@ class PokemonInfoPage extends StatelessWidget {
                 ),
               ),
             ],
+          ),
+        ),
+        Expanded(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: themeData.primaryColor,
+              borderRadius: infoPageModalRadius,
+            ),
+            child: Padding(
+              padding: infoPageModalPadding,
+              child: DefaultTabController(
+                length: tabLabels.length,
+                child: Column(
+                  children: [
+                    TabBar(
+                      labelColor: typeDecorationColor,
+                      indicatorColor: typeDecorationColor,
+                      unselectedLabelColor: themeData.unselectedWidgetColor,
+                      tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
+                    ),
+                    const Expanded(
+                      child: TabBarView(
+                        children: [
+                          SizedBox(),
+                          SizedBox(),
+                          SizedBox(),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
           ),
         ),
       ],

--- a/bloc/lib/utils/const.dart
+++ b/bloc/lib/utils/const.dart
@@ -15,3 +15,5 @@ const debouncerDelayInMilliseconds = 300;
 const idNumberPadWidth = 3;
 const infoPageHeaderPadding = EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0);
 const infoPageImageSize = 200.0;
+const infoPageModalPadding = EdgeInsets.symmetric(horizontal: 4.0);
+const infoPageModalRadius = BorderRadius.vertical(top: Radius.circular(20.0));

--- a/bloc/lib/utils/strings.dart
+++ b/bloc/lib/utils/strings.dart
@@ -7,3 +7,4 @@ const getMorePokemonKey = 'get-more-pokemon';
 const initPokemonListKey = 'init-pokemon-list';
 const searchFieldHintText = 'Search Pokemon';
 const searchPokemonKey = 'search-pokemon';
+const tabLabels = ['About', 'Evolution', 'Moves'];

--- a/riverpod/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/riverpod/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -52,17 +52,19 @@ class PokemonInfoPage extends ConsumerWidget {
           ),
         ),
         Expanded(
-          child: Container(
-            padding: infoPageModalPadding,
+          child: DecoratedBox(
             decoration: BoxDecoration(
               color: context.themeData.primaryColor,
               borderRadius: infoPageModalRadius,
             ),
-            child: DefaultTabController(
-              length: tabLabels.length,
-              child: const Material(
-                color: Colors.transparent,
-                child: InfoTabBody(),
+            child: Padding(
+              padding: infoPageModalPadding,
+              child: DefaultTabController(
+                length: tabLabels.length,
+                child: const Material(
+                  color: Colors.transparent,
+                  child: InfoTabBody(),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
- add initial pokemon info modal in pokemon info page with about, evolution, and moves tabs
- use decorated box and padding instead of container in async redux and riverpod pokemon info page