### PR TITLE
feat: [Bloc] get pokemon species

### DIFF
--- a/bloc/lib/apis/model/evolution_chain_info.dart
+++ b/bloc/lib/apis/model/evolution_chain_info.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_bloc/utils/typedef.dart';
+
+part 'evolution_chain_info.freezed.dart';
+part 'evolution_chain_info.g.dart';
+
+@freezed
+abstract class EvolutionChainInfo with _$EvolutionChainInfo {
+  const factory EvolutionChainInfo({
+    @Default('') @JsonKey(name: 'url') String url,
+  }) = _EvolutionChainInfo;
+
+  factory EvolutionChainInfo.fromJson(Json json) => _$EvolutionChainInfoFromJson(json);
+}

--- a/bloc/lib/apis/model/flavor_text_entry.dart
+++ b/bloc/lib/apis/model/flavor_text_entry.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_bloc/apis/model/pokemon_info.dart';
+import 'package:pokedex_flutter_bloc/utils/typedef.dart';
+
+part 'flavor_text_entry.freezed.dart';
+part 'flavor_text_entry.g.dart';
+
+@freezed
+abstract class FlavorTextEntry with _$FlavorTextEntry {
+  const factory FlavorTextEntry({
+    @Default('') @JsonKey(name: 'flavor_text') String flavorText,
+    @Default(PokemonInfo()) @JsonKey(name: 'language') PokemonInfo languageInfo,
+  }) = _FlavorTextEntry;
+
+  factory FlavorTextEntry.fromJson(Json json) => _$FlavorTextEntryFromJson(json);
+}

--- a/bloc/lib/apis/model/pokemon_species.dart
+++ b/bloc/lib/apis/model/pokemon_species.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pokedex_flutter_bloc/apis/model/evolution_chain_info.dart';
+import 'package:pokedex_flutter_bloc/apis/model/flavor_text_entry.dart';
+import 'package:pokedex_flutter_bloc/utils/typedef.dart';
+
+part 'pokemon_species.freezed.dart';
+part 'pokemon_species.g.dart';
+
+@freezed
+abstract class PokemonSpecies with _$PokemonSpecies {
+  const factory PokemonSpecies({
+    @Default(EvolutionChainInfo()) @JsonKey(name: 'evolution_chain') EvolutionChainInfo evolutionChainInfo,
+    @Default(<FlavorTextEntry>[]) @JsonKey(name: 'flavor_text_entries') List<FlavorTextEntry> flavorTextEntries,
+  }) = _PokemonSpecies;
+
+  factory PokemonSpecies.fromJson(Json json) => _$PokemonSpeciesFromJson(json);
+}

--- a/bloc/lib/apis/pokemon_api.dart
+++ b/bloc/lib/apis/pokemon_api.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:pokedex_flutter_bloc/apis/api_client.dart';
 import 'package:pokedex_flutter_bloc/apis/model/pokemon.dart';
+import 'package:pokedex_flutter_bloc/apis/model/pokemon_species.dart';
 import 'package:pokedex_flutter_bloc/apis/model/simple_pokemon.dart';
 import 'package:pokedex_flutter_bloc/apis/model/simple_pokemon_list.dart';
 import 'package:pokedex_flutter_bloc/utils/extension.dart';
@@ -45,5 +46,12 @@ class PokemonApi {
     } on DioException catch (_) {
       return List.empty();
     }
+  }
+
+  Future<PokemonSpecies> getSpecies({required String speciesUrl}) async {
+    final response = await apiClient.dio.get<Json>(speciesUrl);
+    final pokemonSpecies = PokemonSpecies.fromJson(response.data!);
+
+    return pokemonSpecies;
   }
 }

--- a/bloc/lib/cubit/app_cubit.dart
+++ b/bloc/lib/cubit/app_cubit.dart
@@ -145,6 +145,14 @@ class AppCubit extends Cubit<AppState> {
     );
   }
 
+  void getPokemonSpecies(String speciesUrl) => _loadingAction(
+    getPokemonSpeciesKey,
+    () async {
+      final species = await ApiService.pokemonApi.getSpecies(speciesUrl: speciesUrl);
+      emit(state.copyWith(pokemonSpecies: species));
+    },
+  );
+
   Future<void> _loadingAction(String waitKey, AsyncCallback function) async {
     if (state.waitKey == waitKey) return;
 

--- a/bloc/lib/cubit/app_state.dart
+++ b/bloc/lib/cubit/app_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pokedex_flutter_bloc/apis/model/pokemon.dart';
+import 'package:pokedex_flutter_bloc/apis/model/pokemon_species.dart';
 import 'package:pokedex_flutter_bloc/apis/model/simple_pokemon_list.dart';
 import 'package:pokedex_flutter_bloc/utils/typedef.dart';
 
@@ -15,5 +16,6 @@ abstract class AppState with _$AppState {
     @Default(<Pokemon>[]) PokemonList searchResultList,
     @Default('') String waitKey,
     @Default(false) bool isSearching,
+    @Default(PokemonSpecies()) PokemonSpecies pokemonSpecies,
   }) = _AppState;
 }

--- a/bloc/lib/extensions/pokemon_species_ext.dart
+++ b/bloc/lib/extensions/pokemon_species_ext.dart
@@ -1,0 +1,11 @@
+import 'package:pokedex_flutter_bloc/apis/model/pokemon_species.dart';
+import 'package:pokedex_flutter_bloc/utils/extension.dart';
+import 'package:pokedex_flutter_bloc/utils/strings.dart';
+
+extension PokemonSpeciesExt on PokemonSpecies {
+  String get flavorTextEnglish => flavorTextEntries
+      .firstWhereForLoop((flavorText) => flavorText.languageInfo.name == english)
+      .flavorText
+      .replaceAll('\n', ' ')
+      .replaceAll('\u000c', ' ');
+}

--- a/bloc/lib/feature/pokemon_info/widgets/about_tab.dart
+++ b/bloc/lib/feature/pokemon_info/widgets/about_tab.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pokedex_flutter_bloc/apis/model/pokemon.dart';
+import 'package:pokedex_flutter_bloc/classes/pokemon_color_picker.dart';
+import 'package:pokedex_flutter_bloc/cubit/app_cubit.dart';
+import 'package:pokedex_flutter_bloc/extensions/pokemon_ext.dart';
+import 'package:pokedex_flutter_bloc/extensions/pokemon_species_ext.dart';
+import 'package:pokedex_flutter_bloc/utils/const.dart';
+import 'package:pokedex_flutter_bloc/utils/extension.dart';
+
+class AboutTab extends StatelessWidget {
+  const AboutTab({
+    required this.selectedPokemon,
+    super.key,
+  });
+
+  final Pokemon selectedPokemon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: aboutTabPadding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: flavorTextPadding,
+            child: Text(
+              context.read<AppCubit>().state.pokemonSpecies.flavorTextEnglish,
+              textAlign: TextAlign.center,
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: PokemonColorPicker.typeDecorationColor(selectedPokemon.primaryColor, isDarkened: true),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/bloc/lib/utils/const.dart
+++ b/bloc/lib/utils/const.dart
@@ -17,3 +17,5 @@ const infoPageHeaderPadding = EdgeInsets.symmetric(vertical: 8.0, horizontal: 16
 const infoPageImageSize = 200.0;
 const infoPageModalPadding = EdgeInsets.symmetric(horizontal: 4.0);
 const infoPageModalRadius = BorderRadius.vertical(top: Radius.circular(20.0));
+const aboutTabPadding = EdgeInsets.all(16.0);
+const flavorTextPadding = EdgeInsets.only(top: 8.0, bottom: 16.0);

--- a/bloc/lib/utils/extension.dart
+++ b/bloc/lib/utils/extension.dart
@@ -19,4 +19,13 @@ extension ListExt<T> on List<T> {
 
     return result;
   }
+
+  T firstWhereForLoop(bool Function(T element) test) {
+    for (int i = 0; i < length; i++) {
+      final element = this[i];
+      if (test(element)) return element;
+    }
+
+    throw StateError('No element');
+  }
 }

--- a/bloc/lib/utils/strings.dart
+++ b/bloc/lib/utils/strings.dart
@@ -8,3 +8,5 @@ const initPokemonListKey = 'init-pokemon-list';
 const searchFieldHintText = 'Search Pokemon';
 const searchPokemonKey = 'search-pokemon';
 const tabLabels = ['About', 'Evolution', 'Moves'];
+const english = 'en';
+const getPokemonSpeciesKey = 'get-pokemon-species';


### PR DESCRIPTION
- add list extension for first where for loop
- create about tab widget and use in pokemon info page
- add models for evolution chain info, flavor text entry, and pokemon species
- add getting species in pokemon api and app cubit and use in start of pokemon info page
- add pokemon species property in app state
- add pokemon species extension for getting flavor text english and use in about tab
- use loading indicator in pokemon info page when getting pokemon species