### PR TITLE
chore: dart 3.9.2

### DIFF
--- a/async_redux/analysis_options.yaml
+++ b/async_redux/analysis_options.yaml
@@ -11,6 +11,9 @@ analyzer:
   errors:
     invalid_annotation_target: ignore
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     always_declare_return_types: true

--- a/async_redux/lib/classes/pokemon_color_picker.dart
+++ b/async_redux/lib/classes/pokemon_color_picker.dart
@@ -3,26 +3,26 @@ import 'package:pokedex_flutter_async_redux/utils/const.dart';
 
 class PokemonColorPicker {
   static Color getColor(String type) => switch (type) {
-        'normal' => const Color(0xffA8A77A),
-        'fire' => const Color(0xffF5AC78),
-        'water' => const Color(0xff9DB7F5),
-        'electric' => const Color(0xffF7D02C),
-        'grass' => const Color(0xffA7DB8D),
-        'ice' => const Color(0xff96D9D6),
-        'fighting' => const Color(0xffC22E28),
-        'poison' => const Color(0xffA33EA1),
-        'ground' => const Color(0xffE2BF65),
-        'flying' => const Color(0xffA98FF3),
-        'psychic' => const Color(0xffF95587),
-        'bug' => const Color(0xffA6B91A),
-        'rock' => const Color(0xffB6A136),
-        'ghost' => const Color(0xff735797),
-        'dragon' => const Color(0xff6F35FC),
-        'dark' => const Color(0xff705746),
-        'steel' => const Color(0xffB7B7CE),
-        'fairy' => const Color(0xffD685AD),
-        _ => const Color(0xffffffff),
-      };
+    'normal' => const Color(0xffA8A77A),
+    'fire' => const Color(0xffF5AC78),
+    'water' => const Color(0xff9DB7F5),
+    'electric' => const Color(0xffF7D02C),
+    'grass' => const Color(0xffA7DB8D),
+    'ice' => const Color(0xff96D9D6),
+    'fighting' => const Color(0xffC22E28),
+    'poison' => const Color(0xffA33EA1),
+    'ground' => const Color(0xffE2BF65),
+    'flying' => const Color(0xffA98FF3),
+    'psychic' => const Color(0xffF95587),
+    'bug' => const Color(0xffA6B91A),
+    'rock' => const Color(0xffB6A136),
+    'ghost' => const Color(0xff735797),
+    'dragon' => const Color(0xff6F35FC),
+    'dark' => const Color(0xff705746),
+    'steel' => const Color(0xffB7B7CE),
+    'fairy' => const Color(0xffD685AD),
+    _ => const Color(0xffffffff),
+  };
 
   static Color typeDecorationColor(Color color, {bool isDarkened = false}) {
     final hsl = HSLColor.fromColor(color);

--- a/async_redux/lib/feature/pokemon_info/pokemon_info_page.dart
+++ b/async_redux/lib/feature/pokemon_info/pokemon_info_page.dart
@@ -85,33 +85,34 @@ class PokemonInfoPage extends StatelessWidget {
                 color: Colors.transparent,
                 child: DefaultTabController(
                   length: tabLabels.length,
-                  child: isLoading
-                      ? LoadingIndicator(color: typeDecorationColor)
-                      : Column(
-                          children: [
-                            TabBar(
-                              labelColor: typeDecorationColor,
-                              indicatorColor: typeDecorationColor,
-                              unselectedLabelColor: themeData.unselectedWidgetColor,
-                              tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
-                            ),
-                            Expanded(
-                              child: TabBarView(
-                                children: [
-                                  AboutTab(
-                                    selectedPokemon: selectedPokemon,
-                                    flavorTextEnglish: pokemonSpecies.flavorTextEnglish,
-                                  ),
-                                  EvolutionTab(
-                                    pokemonEvolutionChain: pokemonEvolutionChain,
-                                    pokemonEvolutionList: pokemonEvolutionList,
-                                  ),
-                                  MovesTab(selectedPokemon: selectedPokemon),
-                                ],
-                              ),
-                            ),
-                          ],
+                  child: switch (isLoading) {
+                    true => LoadingIndicator(color: typeDecorationColor),
+                    false => Column(
+                      children: [
+                        TabBar(
+                          labelColor: typeDecorationColor,
+                          indicatorColor: typeDecorationColor,
+                          unselectedLabelColor: themeData.unselectedWidgetColor,
+                          tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
                         ),
+                        Expanded(
+                          child: TabBarView(
+                            children: [
+                              AboutTab(
+                                selectedPokemon: selectedPokemon,
+                                flavorTextEnglish: pokemonSpecies.flavorTextEnglish,
+                              ),
+                              EvolutionTab(
+                                pokemonEvolutionChain: pokemonEvolutionChain,
+                                pokemonEvolutionList: pokemonEvolutionList,
+                              ),
+                              MovesTab(selectedPokemon: selectedPokemon),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  },
                 ),
               ),
             ),

--- a/async_redux/lib/feature/pokemon_info/pokemon_info_vm.dart
+++ b/async_redux/lib/feature/pokemon_info/pokemon_info_vm.dart
@@ -10,12 +10,12 @@ import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
 class PokemonInfoVmFactory extends VmFactory<AppState, PokemonInfoConnector, PokemonInfoVm> {
   @override
   PokemonInfoVm fromStore() => PokemonInfoVm(
-        selectedPokemon: state.selectedPokemon ?? const Pokemon(),
-        isLoading: state.wait.isWaiting(InitPokemonInfoPageAction.waitKey),
-        pokemonSpecies: state.pokemonSpecies ?? const PokemonSpecies(),
-        pokemonEvolutionChain: state.pokemonEvolutionChain ?? const PokemonEvolutionChain(),
-        pokemonEvolutionList: state.pokemonEvolutionList,
-      );
+    selectedPokemon: state.selectedPokemon ?? const Pokemon(),
+    isLoading: state.wait.isWaiting(InitPokemonInfoPageAction.waitKey),
+    pokemonSpecies: state.pokemonSpecies ?? const PokemonSpecies(),
+    pokemonEvolutionChain: state.pokemonEvolutionChain ?? const PokemonEvolutionChain(),
+    pokemonEvolutionList: state.pokemonEvolutionList,
+  );
 }
 
 class PokemonInfoVm extends Vm {
@@ -32,12 +32,12 @@ class PokemonInfoVm extends Vm {
     required this.pokemonEvolutionChain,
     required this.pokemonEvolutionList,
   }) : super(
-          equals: [
-            selectedPokemon,
-            pokemonSpecies,
-            isLoading,
-            pokemonEvolutionChain,
-            pokemonEvolutionList,
-          ],
-        );
+         equals: [
+           selectedPokemon,
+           pokemonSpecies,
+           isLoading,
+           pokemonEvolutionChain,
+           pokemonEvolutionList,
+         ],
+       );
 }

--- a/async_redux/lib/feature/pokemon_info/widgets/about_tab.dart
+++ b/async_redux/lib/feature/pokemon_info/widgets/about_tab.dart
@@ -26,8 +26,10 @@ class AboutTab extends StatelessWidget {
     return [
       MapEntry(primaryColor, sprintf(heightValue, [selectedPokemon.heightInDecimeters / 10])),
       MapEntry(lightenColor, sprintf(weightValue, [selectedPokemon.weightInDecimeters / 10])),
-      MapEntry(primaryColor,
-          selectedPokemon.abilityList.forLoop((ability) => ability.abilityInfo.name.capitalize()).join(', ')),
+      MapEntry(
+        primaryColor,
+        selectedPokemon.abilityList.forLoop((ability) => ability.abilityInfo.name.capitalize()).join(', '),
+      ),
       MapEntry(lightenColor, sprintf(xpValue, [selectedPokemon.baseExperience])),
     ];
   }

--- a/async_redux/lib/feature/pokemon_info/widgets/evolution_card.dart
+++ b/async_redux/lib/feature/pokemon_info/widgets/evolution_card.dart
@@ -22,10 +22,10 @@ class EvolutionCard extends StatelessWidget {
   final int? index;
 
   CrossAxisAlignment get _crossAxisAlignment => switch (index) {
-        1 || 2 => CrossAxisAlignment.end,
-        7 || 8 => CrossAxisAlignment.start,
-        _ => CrossAxisAlignment.center,
-      };
+    1 || 2 => CrossAxisAlignment.end,
+    7 || 8 => CrossAxisAlignment.start,
+    _ => CrossAxisAlignment.center,
+  };
 
   @override
   Widget build(BuildContext context) {

--- a/async_redux/lib/feature/pokemon_info/widgets/moves_tab.dart
+++ b/async_redux/lib/feature/pokemon_info/widgets/moves_tab.dart
@@ -28,12 +28,14 @@ class MovesTab extends StatelessWidget {
         spacing: movesSpacing,
         runSpacing: movesSpacing,
         children: selectedPokemon.moveList.forLoop(
-          (move) => Container(
-            padding: movesPadding,
+          (move) => ColoredBox(
             color: selectedPokemon.primaryColor,
-            child: Text(
-              move.moveInfo.name.split('-').forLoop((word) => word.capitalize()).join(' '),
-              style: style,
+            child: Padding(
+              padding: movesPadding,
+              child: Text(
+                move.moveInfo.name.split('-').forLoop((word) => word.capitalize()).join(' '),
+                style: style,
+              ),
             ),
           ),
         ),

--- a/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/async_redux/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -60,12 +60,12 @@ class _PokemonListPageState extends State<PokemonListPage> {
   }
 
   void _showThemeChoiceDialog() => showDialog<void>(
-        context: context,
-        builder: (_) => ThemeChoiceDialog(
-          savedThemeMode: widget.savedThemeMode,
-          onSelectTheme: _onSelectTheme,
-        ),
-      );
+    context: context,
+    builder: (_) => ThemeChoiceDialog(
+      savedThemeMode: widget.savedThemeMode,
+      onSelectTheme: _onSelectTheme,
+    ),
+  );
 
   void _onSelectOption(String option) {
     if (option == chooseThemeMenuLabel) _showThemeChoiceDialog();
@@ -114,19 +114,20 @@ class _PokemonListPageState extends State<PokemonListPage> {
     return ListScaffold(
       appBarLeading: ValueListenableBuilder<bool>(
         valueListenable: _isSearchingNotifier,
-        builder: (_, isSearching, __) => isSearching
-            ? SearchField(textEditingController: _textEditingController)
-            : Text(
-                appTitle,
-                style: context.textTheme.displayMedium,
-              ),
+        builder: (_, isSearching, _) => switch (isSearching) {
+          true => SearchField(textEditingController: _textEditingController),
+          false => Text(
+            appTitle,
+            style: context.textTheme.displayMedium,
+          ),
+        },
       ),
       appBarActions: [
         IconButton(
           onPressed: _onPressSearch,
           icon: ValueListenableBuilder<bool>(
             valueListenable: _isSearchingNotifier,
-            builder: (_, isSearching, __) => Icon(isSearching ? Icons.close : Icons.search),
+            builder: (_, isSearching, _) => Icon(isSearching ? Icons.close : Icons.search),
           ),
         ),
         IconButton(
@@ -139,7 +140,7 @@ class _PokemonListPageState extends State<PokemonListPage> {
             const PopupMenuItem(
               value: chooseThemeMenuLabel,
               child: Text(chooseThemeMenuLabel),
-            )
+            ),
           ],
         ),
       ],
@@ -149,32 +150,32 @@ class _PokemonListPageState extends State<PokemonListPage> {
           padding: pokemonListPagePadding,
           child: switch (_textEditingController.text.isNotEmpty ? widget.unionSearchPageState : widget.unionPageState) {
             Data<PokemonList>(:final value) => CustomScrollView(
-                controller: _scrollController,
-                slivers: [
-                  SliverGrid(
-                    gridDelegate: pokemonGridDelegate,
-                    delegate: SliverChildBuilderDelegate(
-                      (_, index) {
-                        final pokemon = value[index];
-                        return PokemonCard(
-                          pokemon: pokemon,
-                          onTap: () => _onTapPokemonCard(pokemon),
-                        );
-                      },
-                      childCount: value.length,
-                    ),
+              controller: _scrollController,
+              slivers: [
+                SliverGrid(
+                  gridDelegate: pokemonGridDelegate,
+                  delegate: SliverChildBuilderDelegate(
+                    (_, index) {
+                      final pokemon = value[index];
+                      return PokemonCard(
+                        pokemon: pokemon,
+                        onTap: () => _onTapPokemonCard(pokemon),
+                      );
+                    },
+                    childCount: value.length,
                   ),
-                  if (widget.isGettingMorePokemon)
-                    const SliverToBoxAdapter(
-                      child: Padding(
-                        padding: progressIndicatorFooterPadding,
-                        child: LoadingIndicator(),
-                      ),
-                    )
-                  else
-                    const SliverToBoxAdapter(child: SizedBox(height: pokemonListPageFooterHeight))
-                ],
-              ),
+                ),
+                if (widget.isGettingMorePokemon)
+                  const SliverToBoxAdapter(
+                    child: Padding(
+                      padding: progressIndicatorFooterPadding,
+                      child: LoadingIndicator(),
+                    ),
+                  )
+                else
+                  const SliverToBoxAdapter(child: SizedBox(height: pokemonListPageFooterHeight)),
+              ],
+            ),
             Loading<PokemonList>() => const LoadingIndicator(),
             Error<PokemonList>(:final message) => AlertDialog(title: Text(message ?? '')),
           },

--- a/async_redux/lib/feature/pokemon_list/pokemon_list_vm.dart
+++ b/async_redux/lib/feature/pokemon_list/pokemon_list_vm.dart
@@ -13,16 +13,16 @@ import 'package:pokedex_flutter_async_redux/utils/typedef.dart';
 class PokemonListVmFactory extends VmFactory<AppState, PokemonListConnector, PokemonListVm> {
   @override
   PokemonListVm fromStore() => PokemonListVm(
-        savedThemeMode: state.savedThemeMode,
-        onSetTheme: _onSetTheme,
-        unionPageState: _getLoadingState(),
-        unionSearchPageState: _getSearchingState(),
-        onGetMorePokemon: _onGetMorePokemon,
-        isGettingMorePokemon: state.wait.isWaiting(GetMorePokemonAction.waitKey),
-        onRefreshPage: _onRefreshPage,
-        onSearchPokemon: _onSearchPokemon,
-        onSelectPokemon: _onSelectPokemon,
-      );
+    savedThemeMode: state.savedThemeMode,
+    onSetTheme: _onSetTheme,
+    unionPageState: _getLoadingState(),
+    unionSearchPageState: _getSearchingState(),
+    onGetMorePokemon: _onGetMorePokemon,
+    isGettingMorePokemon: state.wait.isWaiting(GetMorePokemonAction.waitKey),
+    onRefreshPage: _onRefreshPage,
+    onSearchPokemon: _onSearchPokemon,
+    onSelectPokemon: _onSelectPokemon,
+  );
 
   void _onSetTheme(ThemeMode themeMode) => dispatch(SetThemeAction(themeMode));
 
@@ -69,11 +69,11 @@ class PokemonListVm extends Vm {
     required this.onSearchPokemon,
     required this.onSelectPokemon,
   }) : super(
-          equals: [
-            savedThemeMode,
-            unionPageState,
-            isGettingMorePokemon,
-            unionSearchPageState,
-          ],
-        );
+         equals: [
+           savedThemeMode,
+           unionPageState,
+           isGettingMorePokemon,
+           unionSearchPageState,
+         ],
+       );
 }

--- a/async_redux/lib/state/action/pokemon_actions.dart
+++ b/async_redux/lib/state/action/pokemon_actions.dart
@@ -160,9 +160,9 @@ class GetPokemonEvolutionListAction extends ReduxAction<AppState> {
 class ClearPokemonInfoPageAction extends ReduxAction<AppState> {
   @override
   AppState reduce() => state.copyWith(
-        selectedPokemon: null,
-        pokemonSpecies: null,
-        pokemonEvolutionChain: null,
-        pokemonEvolutionList: [],
-      );
+    selectedPokemon: null,
+    pokemonSpecies: null,
+    pokemonEvolutionChain: null,
+    pokemonEvolutionList: [],
+  );
 }

--- a/async_redux/lib/utils/router.dart
+++ b/async_redux/lib/utils/router.dart
@@ -9,7 +9,7 @@ part 'router.g.dart';
 final router = GoRouter(
   routes: $appRoutes,
   debugLogDiagnostics: kDebugMode,
-  errorBuilder: (_, __) => const PokemonListConnector(),
+  errorBuilder: (_, _) => const PokemonListConnector(),
   observers: [RouteObserver<ModalRoute<void>>()],
 );
 
@@ -18,7 +18,7 @@ final router = GoRouter(
   routes: [
     TypedGoRoute<PokemonInfoRoute>(
       path: 'pokemon-info',
-    )
+    ),
   ],
 )
 class PokemonListRoute extends GoRouteData with $PokemonListRoute {

--- a/async_redux/lib/widgets/pokemon_type_list.dart
+++ b/async_redux/lib/widgets/pokemon_type_list.dart
@@ -33,11 +33,12 @@ class PokemonTypeList extends StatelessWidget {
         ),
     ];
 
-    return isDecorationShown
-        ? Row(children: children)
-        : Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
-          );
+    return switch (isDecorationShown) {
+      true => Row(children: children),
+      false => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: children,
+      ),
+    };
   }
 }

--- a/async_redux/lib/widgets/pokemon_type_name.dart
+++ b/async_redux/lib/widgets/pokemon_type_name.dart
@@ -19,12 +19,13 @@ class PokemonTypeName extends StatelessWidget {
     return Container(
       padding: pokemonTypeNamePadding,
       margin: pokemonTypeNameMargin,
-      decoration: primaryColor == null
-          ? null
-          : BoxDecoration(
-              color: PokemonColorPicker.typeDecorationColor(primaryColor!),
-              borderRadius: BorderRadius.circular(typeNameRadius),
-            ),
+      decoration: switch (primaryColor == null) {
+        true => null,
+        false => BoxDecoration(
+          color: PokemonColorPicker.typeDecorationColor(primaryColor!),
+          borderRadius: BorderRadius.circular(typeNameRadius),
+        ),
+      },
       child: Text(
         name.capitalize(),
         style: context.textTheme.headlineMedium,

--- a/async_redux/pubspec.lock
+++ b/async_redux/pubspec.lock
@@ -1019,5 +1019,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.2 <4.0.0"
   flutter: ">=3.32.0"

--- a/async_redux/pubspec.yaml
+++ b/async_redux/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.5.3
+  sdk: ^3.9.2
 
 dependencies:
   flutter:

--- a/bloc/lib/feature/pokemon_info/widgets/moves_tab.dart
+++ b/bloc/lib/feature/pokemon_info/widgets/moves_tab.dart
@@ -28,12 +28,14 @@ class MovesTab extends StatelessWidget {
         spacing: movesSpacing,
         runSpacing: movesSpacing,
         children: selectedPokemon.moveList.forLoop(
-          (move) => Container(
-            padding: movesPadding,
+          (move) => ColoredBox(
             color: selectedPokemon.primaryColor,
-            child: Text(
-              move.moveInfo.name.split('-').forLoop((word) => word.capitalize()).join(' '),
-              style: style,
+            child: Padding(
+              padding: movesPadding,
+              child: Text(
+                move.moveInfo.name.split('-').forLoop((word) => word.capitalize()).join(' '),
+                style: style,
+              ),
             ),
           ),
         ),

--- a/bloc/lib/widgets/pokemon_type_list.dart
+++ b/bloc/lib/widgets/pokemon_type_list.dart
@@ -33,11 +33,12 @@ class PokemonTypeList extends StatelessWidget {
         ),
     ];
 
-    return isDecorationShown
-        ? Row(children: children)
-        : Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
-          );
+    return switch (isDecorationShown) {
+      true => Row(children: children),
+      false => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: children,
+      ),
+    };
   }
 }

--- a/bloc/lib/widgets/pokemon_type_name.dart
+++ b/bloc/lib/widgets/pokemon_type_name.dart
@@ -19,12 +19,13 @@ class PokemonTypeName extends StatelessWidget {
     return Container(
       padding: pokemonTypeNamePadding,
       margin: pokemonTypeNameMargin,
-      decoration: primaryColor == null
-          ? null
-          : BoxDecoration(
-              color: PokemonColorPicker.typeDecorationColor(primaryColor!),
-              borderRadius: BorderRadius.circular(typeNameRadius),
-            ),
+      decoration: switch (primaryColor == null) {
+        true => null,
+        false => BoxDecoration(
+          color: PokemonColorPicker.typeDecorationColor(primaryColor!),
+          borderRadius: BorderRadius.circular(typeNameRadius),
+        ),
+      },
       child: Text(
         name.capitalize(),
         style: context.textTheme.headlineMedium,

--- a/riverpod/analysis_options.yaml
+++ b/riverpod/analysis_options.yaml
@@ -13,6 +13,9 @@ analyzer:
   errors:
     invalid_annotation_target: ignore
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     always_declare_return_types: true

--- a/riverpod/lib/classes/pokemon_color_picker.dart
+++ b/riverpod/lib/classes/pokemon_color_picker.dart
@@ -3,26 +3,26 @@ import 'package:pokedex_flutter_riverpod/utils/const.dart';
 
 class PokemonColorPicker {
   static Color getColor(String type) => switch (type) {
-        'normal' => const Color(0xffA8A77A),
-        'fire' => const Color(0xffF5AC78),
-        'water' => const Color(0xff9DB7F5),
-        'electric' => const Color(0xffF7D02C),
-        'grass' => const Color(0xffA7DB8D),
-        'ice' => const Color(0xff96D9D6),
-        'fighting' => const Color(0xffC22E28),
-        'poison' => const Color(0xffA33EA1),
-        'ground' => const Color(0xffE2BF65),
-        'flying' => const Color(0xffA98FF3),
-        'psychic' => const Color(0xffF95587),
-        'bug' => const Color(0xffA6B91A),
-        'rock' => const Color(0xffB6A136),
-        'ghost' => const Color(0xff735797),
-        'dragon' => const Color(0xff6F35FC),
-        'dark' => const Color(0xff705746),
-        'steel' => const Color(0xffB7B7CE),
-        'fairy' => const Color(0xffD685AD),
-        _ => const Color(0xffffffff),
-      };
+    'normal' => const Color(0xffA8A77A),
+    'fire' => const Color(0xffF5AC78),
+    'water' => const Color(0xff9DB7F5),
+    'electric' => const Color(0xffF7D02C),
+    'grass' => const Color(0xffA7DB8D),
+    'ice' => const Color(0xff96D9D6),
+    'fighting' => const Color(0xffC22E28),
+    'poison' => const Color(0xffA33EA1),
+    'ground' => const Color(0xffE2BF65),
+    'flying' => const Color(0xffA98FF3),
+    'psychic' => const Color(0xffF95587),
+    'bug' => const Color(0xffA6B91A),
+    'rock' => const Color(0xffB6A136),
+    'ghost' => const Color(0xff735797),
+    'dragon' => const Color(0xff6F35FC),
+    'dark' => const Color(0xff705746),
+    'steel' => const Color(0xffB7B7CE),
+    'fairy' => const Color(0xffD685AD),
+    _ => const Color(0xffffffff),
+  };
 
   static Color typeDecorationColor(Color color, {bool isDarkened = false}) {
     final hsl = HSLColor.fromColor(color);

--- a/riverpod/lib/feature/pokemon_info/widgets/about_tab.dart
+++ b/riverpod/lib/feature/pokemon_info/widgets/about_tab.dart
@@ -27,8 +27,10 @@ class AboutTab extends ConsumerWidget {
     return [
       MapEntry(primaryColor, sprintf(heightValue, [selectedPokemon.heightInDecimeters / 10])),
       MapEntry(lightenColor, sprintf(weightValue, [selectedPokemon.weightInDecimeters / 10])),
-      MapEntry(primaryColor,
-          selectedPokemon.abilityList.forLoop((ability) => ability.abilityInfo.name.capitalize()).join(', ')),
+      MapEntry(
+        primaryColor,
+        selectedPokemon.abilityList.forLoop((ability) => ability.abilityInfo.name.capitalize()).join(', '),
+      ),
       MapEntry(lightenColor, sprintf(xpValue, [selectedPokemon.baseExperience])),
     ];
   }

--- a/riverpod/lib/feature/pokemon_info/widgets/evolution_card.dart
+++ b/riverpod/lib/feature/pokemon_info/widgets/evolution_card.dart
@@ -22,10 +22,10 @@ class EvolutionCard extends StatelessWidget {
   final int? index;
 
   CrossAxisAlignment get _crossAxisAlignment => switch (index) {
-        1 || 2 => CrossAxisAlignment.end,
-        7 || 8 => CrossAxisAlignment.start,
-        _ => CrossAxisAlignment.center,
-      };
+    1 || 2 => CrossAxisAlignment.end,
+    7 || 8 => CrossAxisAlignment.start,
+    _ => CrossAxisAlignment.center,
+  };
 
   @override
   Widget build(BuildContext context) {

--- a/riverpod/lib/feature/pokemon_info/widgets/info_tab_body.dart
+++ b/riverpod/lib/feature/pokemon_info/widgets/info_tab_body.dart
@@ -45,7 +45,7 @@ class InfoTabBody extends ConsumerWidget {
           ),
         ],
       ),
-      error: (_, __) => const SizedBox(),
+      error: (_, _) => const SizedBox(),
       loading: () => LoadingIndicator(color: typeDecorationColor),
     );
   }

--- a/riverpod/lib/feature/pokemon_info/widgets/moves_tab.dart
+++ b/riverpod/lib/feature/pokemon_info/widgets/moves_tab.dart
@@ -28,12 +28,14 @@ class MovesTab extends StatelessWidget {
         spacing: movesSpacing,
         runSpacing: movesSpacing,
         children: selectedPokemon.moveList.forLoop(
-          (move) => Container(
-            padding: movesPadding,
+          (move) => ColoredBox(
             color: selectedPokemon.primaryColor,
-            child: Text(
-              move.moveInfo.name.split('-').forLoop((word) => word.capitalize()).join(' '),
-              style: style,
+            child: Padding(
+              padding: movesPadding,
+              child: Text(
+                move.moveInfo.name.split('-').forLoop((word) => word.capitalize()).join(' '),
+                style: style,
+              ),
             ),
           ),
         ),

--- a/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
+++ b/riverpod/lib/feature/pokemon_list/pokemon_list_page.dart
@@ -40,12 +40,12 @@ class _PokemonListPageState extends ConsumerState<PokemonListPage> {
   }
 
   void _showThemeChoiceDialog() => showDialog<void>(
-        context: context,
-        builder: (_) => ThemeChoiceDialog(
-          savedThemeMode: ref.read(selectedThemeProvider),
-          onSelectTheme: _onSelectTheme,
-        ),
-      );
+    context: context,
+    builder: (_) => ThemeChoiceDialog(
+      savedThemeMode: ref.read(selectedThemeProvider),
+      onSelectTheme: _onSelectTheme,
+    ),
+  );
 
   void _onSelectOption(String option) {
     if (option == chooseThemeMenuLabel) _showThemeChoiceDialog();
@@ -94,19 +94,20 @@ class _PokemonListPageState extends ConsumerState<PokemonListPage> {
     return ListScaffold(
       appBarLeading: ValueListenableBuilder<bool>(
         valueListenable: _isSearchingNotifier,
-        builder: (_, isSearching, __) => isSearching
-            ? SearchField(textEditingController: _textEditingController)
-            : Text(
-                appTitle,
-                style: context.textTheme.displayMedium,
-              ),
+        builder: (_, isSearching, _) => switch (isSearching) {
+          true => SearchField(textEditingController: _textEditingController),
+          false => Text(
+            appTitle,
+            style: context.textTheme.displayMedium,
+          ),
+        },
       ),
       appBarActions: [
         IconButton(
           onPressed: _onPressSearch,
           icon: ValueListenableBuilder<bool>(
             valueListenable: _isSearchingNotifier,
-            builder: (_, isSearching, __) => Icon(isSearching ? Icons.close : Icons.search),
+            builder: (_, isSearching, _) => Icon(isSearching ? Icons.close : Icons.search),
           ),
         ),
         IconButton(

--- a/riverpod/lib/feature/pokemon_list/widgets/infinite_list.dart
+++ b/riverpod/lib/feature/pokemon_list/widgets/infinite_list.dart
@@ -23,8 +23,9 @@ class InfiniteList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final searchText = ref.watch(searchTextProvider);
-    final pokemonListValue =
-        searchText.isEmpty ? ref.watch(pokemonListRefProvider) : ref.watch(searchResultListProvider(searchText));
+    final pokemonListValue = searchText.isEmpty
+        ? ref.watch(pokemonListRefProvider)
+        : ref.watch(searchResultListProvider(searchText));
 
     return pokemonListValue.when(
       data: (pokemonList) => CustomScrollView(
@@ -47,7 +48,7 @@ class InfiniteList extends ConsumerWidget {
         ],
       ),
       loading: LoadingIndicator.new,
-      error: (_, __) => const AlertDialog(title: Text(emptyPokemonLabel)),
+      error: (_, _) => const AlertDialog(title: Text(emptyPokemonLabel)),
     );
   }
 }

--- a/riverpod/lib/providers/search_result_list_provider.dart
+++ b/riverpod/lib/providers/search_result_list_provider.dart
@@ -3,4 +3,5 @@ import 'package:pokedex_flutter_riverpod/providers/pokemon_api_provider.dart';
 import 'package:pokedex_flutter_riverpod/utils/typedef.dart';
 
 final searchResultListProvider = FutureProvider.autoDispose.family<PokemonList, String>(
-    (ref, pokemonName) async => ref.read(pokemonApiProvider).searchPokemon(pokemonName: pokemonName.trim()));
+  (ref, pokemonName) async => ref.read(pokemonApiProvider).searchPokemon(pokemonName: pokemonName.trim()),
+);

--- a/riverpod/lib/utils/router.dart
+++ b/riverpod/lib/utils/router.dart
@@ -9,7 +9,7 @@ part 'router.g.dart';
 final router = GoRouter(
   routes: $appRoutes,
   debugLogDiagnostics: kDebugMode,
-  errorBuilder: (_, __) => const PokemonListPage(),
+  errorBuilder: (_, _) => const PokemonListPage(),
   observers: [RouteObserver<ModalRoute<void>>()],
 );
 
@@ -18,7 +18,7 @@ final router = GoRouter(
   routes: [
     TypedGoRoute<PokemonInfoRoute>(
       path: 'pokemon-info',
-    )
+    ),
   ],
 )
 class PokemonListRoute extends GoRouteData with $PokemonListRoute {

--- a/riverpod/lib/widgets/pokemon_type_list.dart
+++ b/riverpod/lib/widgets/pokemon_type_list.dart
@@ -33,11 +33,12 @@ class PokemonTypeList extends StatelessWidget {
         ),
     ];
 
-    return isDecorationShown
-        ? Row(children: children)
-        : Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
-          );
+    return switch (isDecorationShown) {
+      true => Row(children: children),
+      false => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: children,
+      ),
+    };
   }
 }

--- a/riverpod/lib/widgets/pokemon_type_name.dart
+++ b/riverpod/lib/widgets/pokemon_type_name.dart
@@ -19,12 +19,13 @@ class PokemonTypeName extends StatelessWidget {
     return Container(
       padding: pokemonTypeNamePadding,
       margin: pokemonTypeNameMargin,
-      decoration: primaryColor == null
-          ? null
-          : BoxDecoration(
-              color: PokemonColorPicker.typeDecorationColor(primaryColor!),
-              borderRadius: BorderRadius.circular(typeNameRadius),
-            ),
+      decoration: switch (primaryColor == null) {
+        true => null,
+        false => BoxDecoration(
+          color: PokemonColorPicker.typeDecorationColor(primaryColor!),
+          borderRadius: BorderRadius.circular(typeNameRadius),
+        ),
+      },
       child: Text(
         name.capitalize(),
         style: context.textTheme.headlineMedium,

--- a/riverpod/pubspec.lock
+++ b/riverpod/pubspec.lock
@@ -1094,5 +1094,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.2 <4.0.0"
   flutter: ">=3.29.0"

--- a/riverpod/pubspec.yaml
+++ b/riverpod/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.5.3
+  sdk: ^3.9.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
- set dart sdk to 3.9.2 in async redux and riverpod
- preserve formatter trailing commas in async redux and riverpod
- format all
- remove extra underscores
- switch ternaries to switch cases under builds
- use colored box and padding instead of container in moves tab