### PR TITLE
feat: [Get] get pokemon species

### DIFF
--- a/getx/lib/apis/model/evolution_chain_info.dart
+++ b/getx/lib/apis/model/evolution_chain_info.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:getx/utils/typedef.dart';
+
+part 'evolution_chain_info.freezed.dart';
+part 'evolution_chain_info.g.dart';
+
+@freezed
+abstract class EvolutionChainInfo with _$EvolutionChainInfo {
+  const factory EvolutionChainInfo({
+    @Default('') @JsonKey(name: 'url') String url,
+  }) = _EvolutionChainInfo;
+
+  factory EvolutionChainInfo.fromJson(Json json) => _$EvolutionChainInfoFromJson(json);
+}

--- a/getx/lib/apis/model/flavor_text_entry.dart
+++ b/getx/lib/apis/model/flavor_text_entry.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:getx/apis/model/pokemon_info.dart';
+import 'package:getx/utils/typedef.dart';
+
+part 'flavor_text_entry.freezed.dart';
+part 'flavor_text_entry.g.dart';
+
+@freezed
+abstract class FlavorTextEntry with _$FlavorTextEntry {
+  const factory FlavorTextEntry({
+    @Default('') @JsonKey(name: 'flavor_text') String flavorText,
+    @Default(PokemonInfo()) @JsonKey(name: 'language') PokemonInfo languageInfo,
+  }) = _FlavorTextEntry;
+
+  factory FlavorTextEntry.fromJson(Json json) => _$FlavorTextEntryFromJson(json);
+}

--- a/getx/lib/apis/model/pokemon_species.dart
+++ b/getx/lib/apis/model/pokemon_species.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:getx/apis/model/evolution_chain_info.dart';
+import 'package:getx/apis/model/flavor_text_entry.dart';
+import 'package:getx/utils/typedef.dart';
+
+part 'pokemon_species.freezed.dart';
+part 'pokemon_species.g.dart';
+
+@freezed
+abstract class PokemonSpecies with _$PokemonSpecies {
+  const factory PokemonSpecies({
+    @Default(EvolutionChainInfo()) @JsonKey(name: 'evolution_chain') EvolutionChainInfo evolutionChainInfo,
+    @Default(<FlavorTextEntry>[]) @JsonKey(name: 'flavor_text_entries') List<FlavorTextEntry> flavorTextEntries,
+  }) = _PokemonSpecies;
+
+  factory PokemonSpecies.fromJson(Json json) => _$PokemonSpeciesFromJson(json);
+}

--- a/getx/lib/apis/pokemon_api.dart
+++ b/getx/lib/apis/pokemon_api.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:getx/apis/model/pokemon.dart';
+import 'package:getx/apis/model/pokemon_species.dart';
 import 'package:getx/apis/model/simple_pokemon.dart';
 import 'package:getx/apis/model/simple_pokemon_list.dart';
 import 'package:getx/utils/extension.dart';
@@ -38,5 +39,12 @@ class PokemonApi extends GetConnect {
     } catch (_) {
       return List.empty();
     }
+  }
+
+  Future<PokemonSpecies> getSpecies({required String speciesUrl}) async {
+    final response = await get<Json>(speciesUrl);
+    final pokemonSpecies = PokemonSpecies.fromJson(response.body!);
+
+    return pokemonSpecies;
   }
 }

--- a/getx/lib/controller/pokemon_info_controller.dart
+++ b/getx/lib/controller/pokemon_info_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:get/get.dart';
+import 'package:getx/apis/model/pokemon_species.dart';
+import 'package:getx/apis/pokemon_api.dart';
+
+class PokemonInfoController extends GetxController {
+  PokemonInfoController({required this.speciesUrl});
+
+  final String speciesUrl;
+
+  late Rx<PokemonSpecies> pokemonSpecies = const PokemonSpecies().obs;
+  late RxBool isLoading = false.obs;
+
+  @override
+  void onInit() {
+    _initPokemonInfoPage();
+    super.onInit();
+  }
+
+  void _initPokemonInfoPage() => _loadingAction(
+    () async {
+      final species = await PokemonApi().getSpecies(speciesUrl: speciesUrl);
+      pokemonSpecies.value = species;
+    },
+  );
+
+  Future<void> _loadingAction(AsyncCallback function) async {
+    isLoading.value = true;
+    await function()
+        .onError((error, _) => Get.defaultDialog(title: error.toString()))
+        .whenComplete(() => isLoading.value = false);
+  }
+}

--- a/getx/lib/extensions/pokemon_species_ext.dart
+++ b/getx/lib/extensions/pokemon_species_ext.dart
@@ -1,0 +1,11 @@
+import 'package:getx/apis/model/pokemon_species.dart';
+import 'package:getx/utils/extension.dart';
+import 'package:getx/utils/strings.dart';
+
+extension PokemonSpeciesExt on PokemonSpecies {
+  String get flavorTextEnglish => flavorTextEntries
+      .firstWhereForLoop((flavorText) => flavorText.languageInfo.name == english)
+      .flavorText
+      .replaceAll('\n', ' ')
+      .replaceAll('\u000c', ' ');
+}

--- a/getx/lib/pokemon_info/pokemon_info_page.dart
+++ b/getx/lib/pokemon_info/pokemon_info_page.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:getx/apis/model/pokemon.dart';
 import 'package:getx/classes/pokemon_color_picker.dart';
+import 'package:getx/controller/pokemon_info_controller.dart';
 import 'package:getx/extensions/pokemon_ext.dart';
+import 'package:getx/extensions/pokemon_species_ext.dart';
+import 'package:getx/pokemon_info/widgets/about_tab.dart';
 import 'package:getx/pokemon_info/widgets/info_scaffold.dart';
 import 'package:getx/utils/const.dart';
 import 'package:getx/utils/extension.dart';
 import 'package:getx/utils/strings.dart';
+import 'package:getx/widgets/loading_indicator.dart';
 import 'package:getx/widgets/pokemon_image.dart';
 import 'package:getx/widgets/pokemon_type_list.dart';
 
@@ -20,6 +24,9 @@ class PokemonInfoPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final pokemonInfoController = Get.put<PokemonInfoController>(
+      PokemonInfoController(speciesUrl: selectedPokemon.speciesInfo.detailsUrl),
+    );
     final primaryColor = selectedPokemon.primaryColor;
     final typeDecorationColor = PokemonColorPicker.typeDecorationColor(primaryColor, isDarkened: true);
     final textTheme = context.textTheme;
@@ -69,24 +76,32 @@ class PokemonInfoPage extends StatelessWidget {
               color: Colors.transparent,
               child: DefaultTabController(
                 length: tabLabels.length,
-                child: Column(
-                  children: [
-                    TabBar(
-                      labelColor: typeDecorationColor,
-                      indicatorColor: typeDecorationColor,
-                      unselectedLabelColor: theme.unselectedWidgetColor,
-                      tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
+                child: Obx(
+                  () => switch (pokemonInfoController.isLoading.value) {
+                    true => LoadingIndicator(color: typeDecorationColor),
+                    false => Column(
+                      children: [
+                        TabBar(
+                          labelColor: typeDecorationColor,
+                          indicatorColor: typeDecorationColor,
+                          unselectedLabelColor: theme.unselectedWidgetColor,
+                          tabs: tabLabels.forLoop((tabLabel) => Tab(text: tabLabel)),
+                        ),
+                        Expanded(
+                          child: TabBarView(
+                            children: [
+                              AboutTab(
+                                selectedPokemon: selectedPokemon,
+                                flavorTextEnglish: pokemonInfoController.pokemonSpecies.value.flavorTextEnglish,
+                              ),
+                              const SizedBox(),
+                              const SizedBox(),
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
-                    const Expanded(
-                      child: TabBarView(
-                        children: [
-                          SizedBox(),
-                          SizedBox(),
-                          SizedBox(),
-                        ],
-                      ),
-                    ),
-                  ],
+                  },
                 ),
               ),
             ),

--- a/getx/lib/pokemon_info/widgets/about_tab.dart
+++ b/getx/lib/pokemon_info/widgets/about_tab.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:getx/apis/model/pokemon.dart';
+import 'package:getx/classes/pokemon_color_picker.dart';
+import 'package:getx/extensions/pokemon_ext.dart';
+import 'package:getx/utils/const.dart';
+
+class AboutTab extends StatelessWidget {
+  const AboutTab({
+    required this.selectedPokemon,
+    required this.flavorTextEnglish,
+    super.key,
+  });
+
+  final Pokemon selectedPokemon;
+  final String flavorTextEnglish;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: aboutTabPadding,
+      child: ListView(
+        children: [
+          Padding(
+            padding: flavorTextPadding,
+            child: Text(
+              flavorTextEnglish,
+              textAlign: TextAlign.center,
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: PokemonColorPicker.typeDecorationColor(selectedPokemon.primaryColor, isDarkened: true),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/getx/lib/utils/const.dart
+++ b/getx/lib/utils/const.dart
@@ -17,3 +17,5 @@ const infoPageImageSize = 200.0;
 const idNumberPadWidth = 3;
 const infoPageModalPadding = EdgeInsets.symmetric(horizontal: 4.0);
 const infoPageModalRadius = BorderRadius.vertical(top: Radius.circular(20.0));
+const aboutTabPadding = EdgeInsets.all(16.0);
+const flavorTextPadding = EdgeInsets.only(top: 8.0, bottom: 16.0);

--- a/getx/lib/utils/extension.dart
+++ b/getx/lib/utils/extension.dart
@@ -9,4 +9,13 @@ extension ListExt<T> on List<T> {
 
     return result;
   }
+
+  T firstWhereForLoop(bool Function(T element) test) {
+    for (int i = 0; i < length; i++) {
+      final element = this[i];
+      if (test(element)) return element;
+    }
+
+    throw StateError('No element');
+  }
 }

--- a/getx/lib/utils/strings.dart
+++ b/getx/lib/utils/strings.dart
@@ -8,3 +8,4 @@ const getMorePokemonKey = 'get-more-pokemon';
 const searchFieldHintText = 'Search Pokemon';
 const searchPokemonKey = 'search-pokemon';
 const tabLabels = ['About', 'Evolution', 'Moves'];
+const english = 'en';


### PR DESCRIPTION
- add models for evolution chain info, flavor text entry, and pokemon species
- add getting species method in pokemon api
- create pokemon species extension with flavor text english getter
- add first where for loop method in list extension
- create about tab widget and use in pokemon info page
- create controller pokemon info with pokemon species and is loading properties
- add init pokemon info page and loading action functions in pokemon info controller
- put pokemon info controller in pokemon info page
- set loading in pokemon info page and use obx